### PR TITLE
Add Weights & Biases Logging support

### DIFF
--- a/data/coco128.yaml
+++ b/data/coco128.yaml
@@ -1,0 +1,28 @@
+# COCO 2017 dataset http://cocodataset.org - first 128 training images
+# Train command: python train.py --data coco128.yaml
+# Default dataset location is next to /yolov5:
+#   /parent_folder
+#     /coco128
+#     /yolov5
+
+
+# download command/URL (optional)
+download: https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128.zip
+
+# train and val data as 1) directory: path/images/, 2) file: path/images.txt, or 3) list: [path1/images/, path2/images/]
+train: ../coco128/images/train2017/  # 128 images
+val: ../coco128/images/train2017/  # 128 images
+
+# number of classes
+nc: 80
+
+# class names
+names: ['person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat', 'traffic light',
+        'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',
+        'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
+        'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat', 'baseball glove', 'skateboard', 'surfboard',
+        'tennis racket', 'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple',
+        'sandwich', 'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+        'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote', 'keyboard', 'cell phone',
+        'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock', 'vase', 'scissors', 'teddy bear',
+        'hair drier', 'toothbrush']

--- a/test.py
+++ b/test.py
@@ -166,7 +166,7 @@ def test(data,
                              "scores": {"class_score": conf},
                              "domain": "pixel"} for *xyxy, conf, cls in pred.tolist()]
                 boxes = {"predictions": {"box_data": box_data, "class_labels": names_dict}}  # inference-space
-                wandb_images.append(wandb.Image(img[si], boxes=boxes, caption=Path(paths[si]).stem.name))
+                wandb_images.append(wandb.Image(img[si], boxes=boxes))
             # Clip boxes to image bounds
             clip_coords(pred, (height, width))
 

--- a/test.py
+++ b/test.py
@@ -42,7 +42,8 @@ def test(data,
          dataloader=None,
          save_dir='',
          merge=False,
-         save_txt=False):
+         save_txt=False,
+         log_imgs=0):
     # Initialize/load model and set device
     training = model is not None
     if training:  # called by train.py
@@ -86,6 +87,13 @@ def test(data,
     iouv = torch.linspace(0.5, 0.95, 10).to(device)  # iou vector for mAP@0.5:0.95
     niou = iouv.numel()
 
+    # Logging
+    log_imgs, wandb = min(log_imgs, 100), None  # ceil
+    try:
+        import wandb  # Weights & Biases
+    except ImportError:
+        log_imgs = 0
+        
     # Dataloader
     if not training:
         img = torch.zeros((1, 3, imgsz, imgsz), device=device)  # init img
@@ -99,11 +107,12 @@ def test(data,
         names = model.names if hasattr(model, 'names') else model.module.names
     except:
         names = load_classes(opt.names)
+    names_dict = {k: v for k, v in enumerate(model.names if hasattr(model, 'names') else model.module.names)}
     coco91class = coco80_to_coco91_class()
     s = ('%20s' + '%12s' * 6) % ('Class', 'Images', 'Targets', 'P', 'R', 'mAP@.5', 'mAP@.5:.95')
     p, r, f1, mp, mr, map50, map, t0, t1 = 0., 0., 0., 0., 0., 0., 0., 0., 0.
     loss = torch.zeros(3, device=device)
-    jdict, stats, ap, ap_class = [], [], [], []
+    jdict, stats, ap, ap_class, wandb_images = [], [], [], [], []
     for batch_i, (img, targets, paths, shapes) in enumerate(tqdm(dataloader, desc=s)):
         img = img.to(device, non_blocking=True)
         img = img.half() if half else img.float()  # uint8 to fp16/32
@@ -149,7 +158,15 @@ def test(data,
                     xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
                     with open(txt_path + '.txt', 'a') as f:
                         f.write(('%g ' * 5 + '\n') % (cls, *xywh))  # label format
-
+            # W&B logging
+            if len(wandb_images) < log_imgs:
+                box_data = [{"position": {"minX": xyxy[0], "minY": xyxy[1], "maxX": xyxy[2], "maxY": xyxy[3]},
+                             "class_id": int(cls),
+                             "box_caption": "%s %.3f" % (names_dict[cls], conf),
+                             "scores": {"class_score": conf},
+                             "domain": "pixel"} for *xyxy, conf, cls in pred.tolist()]
+                boxes = {"predictions": {"box_data": box_data, "class_labels": names_dict}}  # inference-space
+                wandb_images.append(wandb.Image(img[si], boxes=boxes, caption=path.name))
             # Clip boxes to image bounds
             clip_coords(pred, (height, width))
 
@@ -229,6 +246,8 @@ def test(data,
     if not training:
         print('Speed: %.1f/%.1f/%.1f ms inference/NMS/total per %gx%g image at batch-size %g' % t)
 
+    if wandb and wandb.run:
+        wandb.log({"Bouding Box Debugging/Images": wandb_images})
     # Save JSON
     if save_json and len(jdict):
         f = 'detections_val2017_%s_results.json' % \

--- a/test.py
+++ b/test.py
@@ -166,7 +166,7 @@ def test(data,
                              "scores": {"class_score": conf},
                              "domain": "pixel"} for *xyxy, conf, cls in pred.tolist()]
                 boxes = {"predictions": {"box_data": box_data, "class_labels": names_dict}}  # inference-space
-                wandb_images.append(wandb.Image(img[si], boxes=boxes, caption=path.name))
+                wandb_images.append(wandb.Image(img[si], boxes=boxes, caption=Path(paths[si]).stem.name))
             # Clip boxes to image bounds
             clip_coords(pred, (height, width))
 


### PR DESCRIPTION
This PR adds support for debugging models using W&B, only if the library is already found installed. When using W&B, users of YOLOV5 can debug their models easily inside a customizable dashboard by logging & comparing performance metrics, system usage metrics (like GPU memory), and predictions.

# Features:
* ## Bonding Box Debugging
Debug you bounding box predictions in real-time.
![4d482f8f.gif](https://api.wandb.ai/files/cayush/images/projects/124111/5d0d13a6.gif)

* ## Automatically log and compare the performance of multiple models
![ezgif com-resize](https://user-images.githubusercontent.com/15766192/95598705-e2570980-0a6d-11eb-870c-60cbb7542b0f.gif)

* ## Supports Resuming
When training is resumed from a previous checkpoint, the metrics and images will continue to be logged in the same W&B dashboard if it exists, otherwise, a new W&B run will be created

* ## Adds no dependencies
The library will work as it is supposed to if `wandb` is not installed and will only log metrics and media files to W&B if it is installed. To enable W&B logging, you just need to install the library using `pip install wandb`

