### PR TITLE
Fix: remove calling function self inside function definition

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -48,7 +48,6 @@ def torch_distributed_zero_first(local_rank: int):
 def init_seeds(seed=0):
     random.seed(seed)
     np.random.seed(seed)
-    init_seeds(seed=seed)
 
 
 def get_latest_run(search_dir='./runs'):


### PR DESCRIPTION
It looks like a typo. No need to call the function itself in the function definition.